### PR TITLE
Feature: Time leases on takes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "express-basic-auth": "^1.2.0",
     "fn-args": "^4.0.0",
     "lodash": "^4.17.15",
+    "parse-duration": "^0.4.4",
     "redis": "^2.8.0",
     "slackbots": "^1.2.0"
   },

--- a/server/src/core/features.js
+++ b/server/src/core/features.js
@@ -15,8 +15,8 @@ const takeApp = (
   remindersService,
   notifier,
   messages
-) => ({app, user}) =>
-  Promise.resolve({app, user})
+) => ({app, user, lease}) =>
+  Promise.resolve({app, user, lease})
          .then(TakeApp(appsService))
          .then(SetReminder(remindersService, messages))
          .then(NotifyTeam(notifier, messages.userHasTakenApp))

--- a/server/src/core/reminders/RemindersService.js
+++ b/server/src/core/reminders/RemindersService.js
@@ -6,11 +6,12 @@ export default class RemindersService {
     this.intervals = {}
   }
 
-  add = async ({app, user, message}) => {
-    await this.remindersRepo.add(app, {app, user, message})
+  add = async ({app, user, message, lease}) => {
+    lease = lease || this.remindIn
+    await this.remindersRepo.add(app, {app, user, message, lease})
 
     this.intervals[app] =
-      setInterval(() => this.notifier.notifyUser(user, message), this.remindIn)
+      setInterval(() => this.notifier.notifyUser(user, message), lease)
   }
 
   remove = async ({app}) => {
@@ -24,9 +25,9 @@ export default class RemindersService {
   reinstateStoredReminders = async () => {
     const list = await this.remindersRepo.all()
 
-    Object.values(list).forEach(({app, user, message}) => {
+    Object.values(list).forEach(({app, user, message, lease}) => {
       this.intervals[app] =
-        setInterval(() => this.notifier.notifyUser(user, message), this.remindIn)
+        setInterval(() => this.notifier.notifyUser(user, message), lease)
     })
   }
 }

--- a/server/src/core/reminders/UseCases.js
+++ b/server/src/core/reminders/UseCases.js
@@ -2,8 +2,8 @@ import { effect } from '../../util/Railway'
 
 export const SetReminder =
   (remindersService, messages) =>
-    effect(async ({app, user}) =>
-      await remindersService.add({app, user, message: messages.areYouDoneWith(app)}))
+    effect(async ({app, user, lease}) =>
+      await remindersService.add({app, user, lease, message: messages.areYouDoneWith(app)}))
 
 export const CancelReminder =
   (remindersService) =>

--- a/server/src/web/Command/Command.js
+++ b/server/src/web/Command/Command.js
@@ -2,10 +2,10 @@ import CommandLineParser from './CommandLineParser'
 
 export default class Command {
   constructor(user, commandLine) {
-    const {name, app, options} = CommandLineParser.parse(commandLine)
+    const {name, app, lease} = CommandLineParser.parse(commandLine)
     this.name = name
     this.app = app
-    this.options = options
+    this.lease = lease
     this.user = user
   }
 
@@ -14,7 +14,7 @@ export default class Command {
 
   invalidCommand = (_) => Promise.reject({message: "Invalid command"})
 
-  run_take   = (Context) => Context.takeApp({app: this.app, user: this.user})
+  run_take   = (Context) => Context.takeApp({app: this.app, user: this.user, lease: this.lease})
   run_return = (Context) => Context.returnApp({app: this.app, user: this.user})
   run_status = (Context) => Context.showStatus()
 

--- a/server/src/web/Command/CommandLineParser.js
+++ b/server/src/web/Command/CommandLineParser.js
@@ -1,15 +1,11 @@
-const parseOptions = (optionPairs) => {
-  if (optionPairs.length < 2) return {}
-
-  const [option, value, ...rest] = optionPairs
-  return Object.assign(parseOptions(rest), {[option.substr(2)]: value})
-}
+import parse from 'parse-duration'
 
 export default {
   parse: (commandLine) => {
-    const [name, app, ...options] = commandLine.replace(/\s+/g, " ") // remove multiple whitespaces
-                                               .replace(/(^ *| *$)/g, "") // remove wh padding on the start/end
-                                               .split(" ")
-    return { name, app, options: parseOptions(options) }
+    const [name, app, lease, ] =
+      commandLine.replace(/\s+/g, " ") // remove multiple whitespaces
+                 .replace(/(^ *| *$)/g, "") // remove padding on the start/end
+                 .split(" ")
+    return { name, app, lease: parse(lease) }
   }
 }

--- a/server/src/web/Rest.js
+++ b/server/src/web/Rest.js
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import cors from 'cors'
 import { pick } from 'lodash/object'
+import parse from 'parse-duration'
 import setupBasicAuth from './HttpBasicAuthHelper'
 
 export default (Context, config = {}, router = new Router()) => {
@@ -9,7 +10,8 @@ export default (Context, config = {}, router = new Router()) => {
   router.use(cors())
 
   router.post('/take', (req, res) => {
-    const context = pick(req.body, ['app', 'user'])
+    const context = pick(req.body, ['app', 'user', 'lease'])
+    context['lease'] = parse(String(context['lease']))
 
     Context.takeApp(context)
            .then(() => res.json(userResponse(`You have taken ${context.app}`)))

--- a/server/test/web/Command/Command.spec.js
+++ b/server/test/web/Command/Command.spec.js
@@ -13,8 +13,15 @@ describe('Command', () => {
   it('runs the "take" command', () => {
     const command = new Command('ivo', 'take appA')
     command.run(Context)
-    expect(Context.takeApp).toBeCalledWith({ app: 'appA', user: 'ivo' })
+    expect(Context.takeApp).toBeCalledWith({ app: 'appA', user: 'ivo', lease: null })
   })
+
+  it('runs the "take" command 2', () => {
+    const command = new Command('ivo', 'take appA 45m')
+    command.run(Context)
+    expect(Context.takeApp).toBeCalledWith({ app: 'appA', user: 'ivo', lease: 2700000 })
+  })
+
 
   it('runs the "return" command', () => {
     const command = new Command('ivo', 'return appA')

--- a/server/test/web/Command/CommandLineParser.spec.js
+++ b/server/test/web/Command/CommandLineParser.spec.js
@@ -1,23 +1,29 @@
 import CommandLineParser from '#/src/web/Command/CommandLineParser'
 
 describe('CommandLineParser', () => {
-  it('given a command line, returns an object with name, app and options', () => {
-    const commandLine = 'return AppA --opt1 valopt1 --opt2 valopt2'
-
+  it('return an object with all known components of the command', () => {
+    const commandLine = 'take appA 45m'
     const parsedCommand = CommandLineParser.parse(commandLine)
 
-    expect(parsedCommand.name).toEqual('return')
-    expect(parsedCommand.app).toEqual('AppA')
-    expect(parsedCommand.options).toEqual({opt1: 'valopt1', opt2: 'valopt2'})
+    expect(parsedCommand.name).toEqual('take')
+    expect(parsedCommand.app).toEqual('appA')
+    expect(parsedCommand.lease).toEqual(2700000)
   })
 
-  it('given a command line with too many extra white spaces, returns an object with name, app and options', () => {
-    const commandLine = '    return     AppA   --opt1  valopt1 --opt2 valopt2    '
-
+  it('lease is optional', () => {
+    const commandLine = 'return AppA'
     const parsedCommand = CommandLineParser.parse(commandLine)
 
     expect(parsedCommand.name).toEqual('return')
     expect(parsedCommand.app).toEqual('AppA')
-    expect(parsedCommand.options).toEqual({opt1: 'valopt1', opt2: 'valopt2'})
+    expect(parsedCommand.lease).toBeNull()
+  })
+
+  it('handles too many whitespaces properly', () => {
+    const commandLine = '    return     AppA   '
+    const parsedCommand = CommandLineParser.parse(commandLine)
+
+    expect(parsedCommand.name).toEqual('return')
+    expect(parsedCommand.app).toEqual('AppA')
   })
 })

--- a/server/test/web/Rest.spec.js
+++ b/server/test/web/Rest.spec.js
@@ -27,6 +27,24 @@ describe('Rest', () => {
               .expect(200, { text: 'You have taken appA' })
     })
 
+    it('allows a user to specify a lease time when taking an available app', async () => {
+      jest.useFakeTimers()
+
+      await request(server())
+              .post('/take')
+              .send({user: 'john', app: 'appA', lease: '10m'})
+              .set('Content-Type', 'application/json')
+              .expect(200, { text: 'You have taken appA' })
+
+      jest.advanceTimersByTime(600000 - 20);
+      expect(Context.notifier.userNotifications).toBeEmpty()
+
+      jest.advanceTimersByTime(20);
+      expect(Context.notifier.userNotifications).toContainEqual(
+        expect.objectContaining({ user: 'john' })
+      )
+    })
+
     it('allows a user to return an app he has taken', async () => {
       await Context.takeApp({app: 'appA', user: 'john'})
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3951,6 +3951,11 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
+parse-duration@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.4.4.tgz#11c0f51a689e97d06c57bd772f7fda7dc013243c"
+  integrity sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"


### PR DESCRIPTION
This allows users to specify a "time lease" when they take an app.

This "time lease" will basically be the interval with which takebot will ask the user if they are done with the app.
The need for this is because sometimes we need to take an app for long periods of time and relying on the default can lead to a LOT of notifications.

